### PR TITLE
fix empty val for SSHAgent

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -190,7 +190,7 @@ func (p Plugin) Exec() error {
 	}
 
 	// setup for using ssh agent (https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds)
-	if p.Build.SSHAgent != "" {
+	if !sshAgentEmpty(p.Build.SSHAgent) {
 		fmt.Printf("ssh agent set to \"%s\"", p.Build.SSHAgent)
 		cmds = append(cmds, commandSSHAgentForwardingSetup(p.Build)...)
 	}
@@ -341,7 +341,7 @@ func commandBuild(build Build) *exec.Cmd {
 	if build.Quiet {
 		args = append(args, "--quiet")
 	}
-	if build.SSHAgent != "" {
+	if !sshAgentEmpty(build.SSHAgent) {
 		args = append(args, "--ssh", build.SSHAgent)
 	}
 
@@ -370,7 +370,7 @@ func commandBuild(build Build) *exec.Cmd {
 	}
 
 	// we need to enable buildkit, for secret support and ssh agent support
-	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || build.SSHAgent != "" {
+	if build.Secret != "" || len(build.SecretEnvs) > 0 || len(build.SecretFiles) > 0 || !sshAgentEmpty(build.SSHAgent) {
 		os.Setenv("DOCKER_BUILDKIT", "1")
 	}
 	return exec.Command(dockerExe, args...)
@@ -565,4 +565,8 @@ func GetDroneDockerExecCmd() string {
 	}
 
 	return "drone-docker"
+}
+
+func sshAgentEmpty(agent string) bool {
+	return agent == "" || agent == "[]"
 }


### PR DESCRIPTION
If I run:

```
/bin/drone-docker
exec build: docker.Build{Remote:"", Name:"00000000", Dockerfile:"Dockerfile", Context:".", Tags:[]string{"latest"}, Args:[]string{}, ArgsEnv:[]string{}, Target:"", Squash:false, Pull:true, CacheFrom:[]string{}, Compress:false, Repo:"", LabelSchema:[]string{}, AutoLabel:true, Labels:[]string{}, Link:"", NoCache:false, Secret:"", SecretEnvs:[]string{}, SecretFiles:[]string{}, AddHost:[]string{}, Quiet:false, SSHAgent:"[]"}exec env: []string{"PWD=/", "DOCKER_HOST=unix:///var/run/docker.sock", "DOCKER_TLS_CERTDIR=/certs", "DOCKER_VERSION=20.10.14", "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm", "DIND_COMMIT=42b1175eda071c0e9121e1d64345928384a93df1", "HOME=/root", "SHLVL=1", "HOSTNAME=7a7a6fbf0cee"}+ /usr/local/bin/dockerd --data-root /var/lib/docker --host=unix:///var/run/docker.sock
```

You can see that drone is setting the default value for SSHAgent to `"[]"`, not sure what's causing this...